### PR TITLE
split team sections, condensed second half

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1746,6 +1746,10 @@
 		font-size: 1.1em;
 	}
 
+	.subtitle {
+		font-size: 1.3em;
+	}
+
 	h4 {
 		font-size: 1em;
 	}
@@ -2060,7 +2064,7 @@
 		.features section {
 			padding: 3.5em 3em 1em 8em ;
 			width: 50%;
-			border-top: solid 1px rgba(255, 255, 255, 0.15);
+			border-top: solid 1px rgba(255, 255, 255, 0.5);
 			position: relative;
 		}
 
@@ -2280,6 +2284,266 @@
 					left: 0;
 					position: relative;
 					top: 0;
+				}
+
+		}
+
+/* Featurettes */
+
+	.featurettes {
+		display: -moz-flex;
+		display: -webkit-flex;
+		display: -ms-flex;
+		display: flex;
+		-moz-flex-wrap: wrap;
+		-webkit-flex-wrap: wrap;
+		-ms-flex-wrap: wrap;
+		flex-wrap: wrap;
+		border-radius: 0.25em;
+		border: solid 1px rgba(255, 255, 255, 0.15);
+		background: rgba(255, 255, 255, 0.05);
+		margin: 0 0 2em 0;
+	}
+
+		.featurettes section {
+			padding: 1em 3em 1em 6em ;
+			width: 50%;
+			border-top: solid 1px rgba(255, 255, 255, 0.15);
+			position: relative;
+		}
+			.featurettes section p, h3 {
+				margin-bottom: 0.5em;
+				line-height: 1.2em;
+			}
+
+			.featurettes section h3 {
+				font-size:0.9em;
+			}
+
+			.featurettes section p {
+				font-size:0.8em;
+			}
+
+			.featurettes section:nth-child(-n + 2) {
+				border-top-width: 0;
+			}
+
+			.featurettes section:nth-child(2n) {
+				border-left: solid 1px rgba(255, 255, 255, 0.15);
+			}
+
+			.featurettes section .icon {
+				-moz-transition: opacity 0.5s ease, -moz-transform 0.5s ease;
+				-webkit-transition: opacity 0.5s ease, -webkit-transform 0.5s ease;
+				-ms-transition: opacity 0.5s ease, -ms-transform 0.5s ease;
+				transition: opacity 0.5s ease, transform 0.5s ease;
+				-moz-transition-delay: 1s;
+				-webkit-transition-delay: 1s;
+				-ms-transition-delay: 1s;
+				transition-delay: 1s;
+				-moz-transform: scale(.9);
+				-webkit-transform: scale(.9);
+				-ms-transform: scale(.9);
+				transform: scale(.9);
+				position: absolute;
+				left: 1em;
+				top: 1em;
+				bottom: 1em;
+				opacity: 1;
+			}
+
+			.featurettes section:nth-child(1) .icon {
+				-moz-transition-delay: 0.15s;
+				-webkit-transition-delay: 0.15s;
+				-ms-transition-delay: 0.15s;
+				transition-delay: 0.15s;
+			}
+
+			.featurettes section:nth-child(2) .icon {
+				-moz-transition-delay: 0.3s;
+				-webkit-transition-delay: 0.3s;
+				-ms-transition-delay: 0.3s;
+				transition-delay: 0.3s;
+			}
+
+			.featurettes section:nth-child(3) .icon {
+				-moz-transition-delay: 0.45s;
+				-webkit-transition-delay: 0.45s;
+				-ms-transition-delay: 0.45s;
+				transition-delay: 0.45s;
+			}
+
+			.featurettes section:nth-child(4) .icon {
+				-moz-transition-delay: 0.6s;
+				-webkit-transition-delay: 0.6s;
+				-ms-transition-delay: 0.6s;
+				transition-delay: 0.6s;
+			}
+
+			.featurettes section:nth-child(5) .icon {
+				-moz-transition-delay: 0.75s;
+				-webkit-transition-delay: 0.75s;
+				-ms-transition-delay: 0.75s;
+				transition-delay: 0.75s;
+			}
+
+			.featurettes section:nth-child(6) .icon {
+				-moz-transition-delay: 0.9s;
+				-webkit-transition-delay: 0.9s;
+				-ms-transition-delay: 0.9s;
+				transition-delay: 0.9s;
+			}
+
+			.featurettes section:nth-child(7) .icon {
+				-moz-transition-delay: 1.05s;
+				-webkit-transition-delay: 1.05s;
+				-ms-transition-delay: 1.05s;
+				transition-delay: 1.05s;
+			}
+
+			.featurettes section:nth-child(8) .icon {
+				-moz-transition-delay: 1.2s;
+				-webkit-transition-delay: 1.2s;
+				-ms-transition-delay: 1.2s;
+				transition-delay: 1.2s;
+			}
+
+			.featurettes section:nth-child(9) .icon {
+				-moz-transition-delay: 1.35s;
+				-webkit-transition-delay: 1.35s;
+				-ms-transition-delay: 1.35s;
+				transition-delay: 1.35s;
+			}
+
+			.featurettes section:nth-child(10) .icon {
+				-moz-transition-delay: 1.5s;
+				-webkit-transition-delay: 1.5s;
+				-ms-transition-delay: 1.5s;
+				transition-delay: 1.5s;
+			}
+
+			.featurettes section:nth-child(11) .icon {
+				-moz-transition-delay: 1.65s;
+				-webkit-transition-delay: 1.65s;
+				-ms-transition-delay: 1.65s;
+				transition-delay: 1.65s;
+			}
+
+			.featurettes section:nth-child(12) .icon {
+				-moz-transition-delay: 1.8s;
+				-webkit-transition-delay: 1.8s;
+				-ms-transition-delay: 1.8s;
+				transition-delay: 1.8s;
+			}
+
+			.featurettes section:nth-child(13) .icon {
+				-moz-transition-delay: 1.95s;
+				-webkit-transition-delay: 1.95s;
+				-ms-transition-delay: 1.95s;
+				transition-delay: 1.95s;
+			}
+
+			.featurettes section:nth-child(14) .icon {
+				-moz-transition-delay: 2.1s;
+				-webkit-transition-delay: 2.1s;
+				-ms-transition-delay: 2.1s;
+				transition-delay: 2.1s;
+			}
+
+			.featurettes section:nth-child(15) .icon {
+				-moz-transition-delay: 2.25s;
+				-webkit-transition-delay: 2.25s;
+				-ms-transition-delay: 2.25s;
+				transition-delay: 2.25s;
+			}
+
+			.featurettes section:nth-child(16) .icon {
+				-moz-transition-delay: 2.4s;
+				-webkit-transition-delay: 2.4s;
+				-ms-transition-delay: 2.4s;
+				transition-delay: 2.4s;
+			}
+
+			.featurettes section:nth-child(17) .icon {
+				-moz-transition-delay: 2.55s;
+				-webkit-transition-delay: 2.55s;
+				-ms-transition-delay: 2.55s;
+				transition-delay: 2.55s;
+			}
+
+			.featurettes section:nth-child(18) .icon {
+				-moz-transition-delay: 2.7s;
+				-webkit-transition-delay: 2.7s;
+				-ms-transition-delay: 2.7s;
+				transition-delay: 2.7s;
+			}
+
+			.featurettes section:nth-child(19) .icon {
+				-moz-transition-delay: 2.85s;
+				-webkit-transition-delay: 2.85s;
+				-ms-transition-delay: 2.85s;
+				transition-delay: 2.85s;
+			}
+
+			.featurettes section:nth-child(20) .icon {
+				-moz-transition-delay: 3.0s;
+				-webkit-transition-delay: 3.0s;
+				-ms-transition-delay: 3.0s;
+				transition-delay: 3.0s;
+			}
+
+		.featurettes.inactive section .icon {
+			-moz-transform: scale(0.5);
+			-webkit-transform: scale(0.5);
+			-ms-transform: scale(0.5);
+			transform: scale(0.5);
+			opacity: 0;
+		}
+
+		@media screen and (max-width: 980px) {
+
+			.featurettes {
+				display: block;
+			}
+
+				.featurettes section {
+					border-top-width: 1px !important;
+					border-left-width: 0 !important;
+					width: 100%;
+				}
+
+					.featurettes section:first-child {
+						border-top-width: 0 !important;
+					}
+
+		}
+
+		@media screen and (max-width: 736px) {
+
+			.featurettes section {
+				padding: 2em 2.5em 0.9em 5.5em ;
+			}
+
+				.featurettes section .icon {
+					left: 1em;
+					top: 1.25em;
+					bottom: 0.5em;
+					float: left;
+				}
+
+		}
+
+		@media screen and (max-width: 480px) {
+
+			.featurettes section {
+				padding: 1em 0.1em 1em 1.5em ;
+			}
+
+				.featurettes section .icon {
+					left: 0;
+					position: relative;
+					top: 0;
+					float: left;
 				}
 
 		}

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -2823,6 +2823,12 @@
 			border: 0.25em solid white;
 		}
 
+		.icon.major.headshot {
+			width: 4.5em;
+			height: 4.5em;
+			top: 3.5em;
+		}
+
 /* Desktop behavior */
 		.icon.major.stack:nth-child(1) {
 			margin-top: -0.5em;

--- a/public/index.html
+++ b/public/index.html
@@ -117,13 +117,32 @@
 					<section id="team" class="wrapper style3 fade-up">
 						<div class="inner">
 							<h2>Who we are</h2>
-							<p>Technology leaders passionate about criminal justice reform from organizations including Google, Microsoft, Opower, and Optimizely.</p>
+							<p>Technology leaders passionate about criminal justice reform from organizations including Google, Apple, Microsoft, Opower, and Optimizely.</p>
+							<h2 class="subtitle"> Core team </h2>
 							<div class="features">
 								<section>
 									<img class="icon major" src="images/clem.jpg" />
 									<h3>Clementine Jacoby</h3>
 									<p>Co-founder and Director, Recidiviz. Product Manager, Google Maps.</p>
 								</section>
+								<section>
+									<img class="icon major" src="images/josh.jpg" />
+									<h3>Joshua Essex</h3>
+									<p>Co-founder and Technical Lead, Recidiviz. Architect and Technical Lead, Opower.</p>
+								</section>
+								<section>
+									<img class="icon major" src="images/andrew.jpg" />
+									<h3>C. Andrew Warren</h3>
+									<p>Co-founder and Product Lead, Recidiviz. Former Product Manager, Google and Sidewalk Labs.</p>
+								</section>
+								<section>
+									<img class="icon major" src="images/julia.jpeg" />
+									<h3>Julia {{last_name}}</h3>
+									<p>{{new_job_title}}, Recidiviz. Former {{old_job_title}}, Apple.</p>
+								</section>
+							</div>
+							<h3 class="subtitle"> Volunteers </h3>
+							<div class="featurettes">
 								<section>
 									<img class="icon major" src="images/anna.jpg" />
 									<h3>Anna Geiduschek</h3>
@@ -133,11 +152,6 @@
 									<img class="icon major" src="images/ben.png" />
 									<h3>Ben Packer</h3>
 									<p>Data Scientist, Recidiviz. Data Scientist, Google. </p>
-								</section>
-								<section>
-									<img class="icon major" src="images/andrew.jpg" />
-									<h3>C. Andrew Warren</h3>
-									<p>Co-founder and Product Lead, Recidiviz. Former Product Manager, Google and Sidewalk Labs.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/erik.jpg" />
@@ -153,11 +167,6 @@
 									<img class="icon major" src="images/jordan.jpg" />
 									<h3>Jordan Bramble</h3>
 									<p>Data Engineer, Recidiviz. Machine Learning Engineer, Atrium. Former Data Scientist, USDS.</p>
-								</section>
-								<section>
-									<img class="icon major" src="images/josh.jpg" />
-									<h3>Joshua Essex</h3>
-									<p>Co-founder and Technical Lead, Recidiviz. Architect and Technical Lead, Opower.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/marie.jpg" />

--- a/public/index.html
+++ b/public/index.html
@@ -121,79 +121,77 @@
 							<h2 class="subtitle"> Core team </h2>
 							<div class="features">
 								<section>
-									<img class="icon major" src="images/clem.jpg" />
+									<img class="icon major headshot" src="images/clem.jpg" />
 									<h3>Clementine Jacoby</h3>
-									<p>Co-founder and Director, Recidiviz. Product Manager, Google Maps.</p>
+									<p>Executive Director & Co-Founder</p>
 								</section>
 								<section>
-									<img class="icon major" src="images/josh.jpg" />
-									<h3>Joshua Essex</h3>
-									<p>Co-founder and Technical Lead, Recidiviz. Architect and Technical Lead, Opower.</p>
-								</section>
-								<section>
-									<img class="icon major" src="images/andrew.jpg" />
+									<img class="icon major headshot" src="images/andrew.jpg" />
 									<h3>C. Andrew Warren</h3>
-									<p>Co-founder and Product Lead, Recidiviz. Former Product Manager, Google and Sidewalk Labs.</p>
+									<p>Product Lead & Co-Founder</p>
 								</section>
 								<section>
-									<img class="icon major" src="images/julia.jpeg" />
-									<h3>Julia {{last_name}}</h3>
-									<p>{{new_job_title}}, Recidiviz. Former {{old_job_title}}, Apple.</p>
+									<img class="icon major headshot" src="images/josh.jpg" />
+									<h3>Joshua Essex</h3>
+									<p>Engineering Lead & Co-Founder </p>
+								</section>
+								<section>
+									<img class="icon major headshot" src="images/julia.jpeg" />
+									<h3>Julia Dressel</h3>
+									<p>Software Engineer & UX</p>
 								</section>
 							</div>
-							<h3 class="subtitle"> Volunteers </h3>
-							<div class="featurettes">
+							<h3 class="subtitle"> Contributors </h3>
+							<div class="featurettes headshot">
 								<section>
 									<img class="icon major" src="images/anna.jpg" />
 									<h3>Anna Geiduschek</h3>
-									<p>Software Engineer, Recidiviz. Software Engineer, Dropbox.</p>
+									<p>Software Engineer, Recidiviz.</br>Software Engineer, Dropbox.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/ben.png" />
 									<h3>Ben Packer</h3>
-									<p>Data Scientist, Recidiviz. Data Scientist, Google. </p>
+									<p>Data Scientist, Recidiviz.</br>Data Scientist, Google. </p>
 								</section>
 								<section>
 									<img class="icon major" src="images/erik.jpg" />
 									<h3>Erik Shilts</h3>
-									<p>Data Scientist and User Experience Researcher, Recidiviz. Director of Data Science, Rally Health.</p>
+									<p>Data Scientist, Recidiviz.</br>Director of Data Science, Rally Health.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/eva.jpg" />
 									<h3>Eva Asplund</h3>
-									<p>Software Engineer, Recidiviz. Software Engineer, Oracle.</p>
+									<p>Software Engineer, Recidiviz.</br>Software Engineer, Oracle.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/jordan.jpg" />
 									<h3>Jordan Bramble</h3>
-									<p>Data Engineer, Recidiviz. Machine Learning Engineer, Atrium. Former Data Scientist, USDS.</p>
+									<p>Data Engineer, Recidiviz.</br>Machine Learning Engineer, Atrium.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/marie.jpg" />
 									<h3>Marie Cosgrove-Davies</h3>
-									<p>Operations Product Manager, Recidiviz. Product Manager, Google Cloud.</p>
+									<p>Product Manager, Recidiviz.</br>Product Manager, Google Cloud.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/root.png" />
 									<h3>Matthew Root</h3>
-									<p>Software Engineer, Recidiviz. Engineering Manager, Optimizely.</p>
+									<p>Software Engineer, Recidiviz.</br>Engineering Manager, Optimizely.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/sachin.jpg" />
 									<h3>Sachin Nene</h3>
-									<p>Software Engineer, Recidiviz. Former Engineering Manager, Opower.</p>
+									<p>Software Engineer, Recidiviz.</br>Engineering, Upside.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/wendy.png" />
 									<h3>Wendy Ginsberg</h3>
-									<p>Software Engineer and Product Manager, Recidiviz. Product Manager, Google.</p>
+									<p>Software Engineer & PM, Recidiviz.</br>Product Manager, Google.</p>
 								</section>
 								<section>
 									<img class="icon major" src="images/placeholder.png" />
 									<h3>You</h3>
 									<p>We're fully open source, <a href="https://github.com/Recidiviz" target="_blank">join us</a>.</p>
-								</section>
-								<section>
 								</section>
 							</div>
 						</div>
@@ -252,7 +250,7 @@
 									<ul class="contact">
 										<li>
 											<h3>Address</h3>
-											<span>1655 Pine Lane<br />Provo, UT 84604<br />United States</span>
+											<span>169 11th Street<br />San Francisco, CA 94103<br />United States</span>
 										</li>
 										<li>
 											<h3>Email</h3>


### PR DESCRIPTION
Changelist tl;dr
- Split sections into two, condensed second section and checked at the 3 breakpoints. 
- Added Julia (but left placeholders for last name, current and former job titles)
- Added Apple to the top list
- "Core team" as section 1 header, and "Volunteers"  as second, though I think there's a better word than "Volunteers" 
